### PR TITLE
hotfix: styling issues in app

### DIFF
--- a/src/components/Country.tsx
+++ b/src/components/Country.tsx
@@ -26,13 +26,7 @@ export default function CountryDetail({
         { [styles.dark_mode]: isDarkMode },
       )}
     >
-      <Link
-        style={{
-          color: "white",
-          textDecoration: "none",
-        }}
-        to={"/"}
-      >
+      <Link to={"/"}>
         <div>{"<"} Back to Home</div>
       </Link>
       {isLoading && <div>Loading...</div>}

--- a/src/components/Country.tsx
+++ b/src/components/Country.tsx
@@ -1,4 +1,7 @@
-import { useLocation } from "react-router-dom";
+import {
+  Link,
+  useLocation,
+} from "react-router-dom";
 import classnames from "classnames";
 import { CountryDarkModeProps } from "../utilities/interface";
 import useCountry from "../hooks/useCountry";
@@ -23,6 +26,15 @@ export default function CountryDetail({
         { [styles.dark_mode]: isDarkMode },
       )}
     >
+      <Link
+        style={{
+          color: "white",
+          textDecoration: "none",
+        }}
+        to={"/"}
+      >
+        <div>{"<"} Back to Home</div>
+      </Link>
       {isLoading && <div>Loading...</div>}
       {error && <div>Error loading data</div>}
       <div

--- a/src/components/ExploreCountries.tsx
+++ b/src/components/ExploreCountries.tsx
@@ -110,8 +110,8 @@ export default function ExploreCountries({
           }
         >
           <div>
-            <label>Min Population:</label>
             <input
+              placeholder={"min population"}
               type="number"
               className={
                 styles.explore_countries_filter_input
@@ -127,8 +127,8 @@ export default function ExploreCountries({
             />
           </div>
           <div>
-            <label>Max Population:</label>
             <input
+              placeholder={"max population"}
               type="number"
               className={
                 styles.explore_countries_filter_input

--- a/src/components/ExploreCountries.tsx
+++ b/src/components/ExploreCountries.tsx
@@ -181,8 +181,9 @@ export default function ExploreCountries({
         (!imagesLoaded && !visibleCountries)) && (
         <div>Loading...</div>
       )}
-      {visibleCountries &&
-        visibleCountries.length === 0 &&
+      {((visibleCountries &&
+        visibleCountries.length === 0) ||
+        !data) &&
         !isLoading && (
           <div>No countries found</div>
         )}

--- a/src/components/components.module.css
+++ b/src/components/components.module.css
@@ -176,6 +176,8 @@
 
 .explore_countries_filter_population_dropdown {
   display: flex;
+  gap: 1rem;
+  justify-content: space-between;
 }
 
 .explore_countries_filter_population_dropdown > div {
@@ -183,9 +185,6 @@
   flex-direction: row;
   gap: 0.5rem;
 }
- .explore_countries_filter_population_dropdown div > label {
-  padding: 0 0.5rem;
- }
 
  .explore_countries_filter_population_dropdown div > input {
   background-color: #fff;
@@ -195,7 +194,6 @@
   display: flex;
   gap: 1rem;
   padding: 0.5rem;
-  width: 2rem;
  }
 
  .explore_countries_filter_region_dropdown {

--- a/src/components/components.module.css
+++ b/src/components/components.module.css
@@ -56,6 +56,11 @@
   padding: 0 5%;
 }
 
+.main_container.dark_mode a:link,
+.main_container.dark_mode a:visited {
+  color: rgba(255, 255, 255, 0.87);
+}
+
 /*
   Flags
 */
@@ -81,8 +86,8 @@
   width: 170px;
 }
 
-.flag_container:link,
-.flag_container:visited {
+.dark_mode .flag_container:link,
+.dark_mode .flag_container:visited {
   color: rgba(255, 255, 255, 0.87);
   text-decoration: none;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -36,7 +36,12 @@ body {
 }
 
 a:link, a:visited {
-  color:#213547
+  color:#213547;
+  text-decoration: none;
+}
+
+.dark-mode a:link, .dark-mode a:visited {
+  color: rgba(255, 255, 255, 0.87);
 }
 
 input {

--- a/src/index.css
+++ b/src/index.css
@@ -39,6 +39,10 @@ a:link, a:visited {
   color:#213547
 }
 
+input {
+  color: #000000;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;


### PR DESCRIPTION
This hotfixes several issues from the original launch, including:

1. the text in the input boxes on the landing page are white - this one hurts. I was making some last minute changes and updated how I was styling that filter bar - in an effort to keep consistent with how I was handling light/dark mode, I think I inadvertently made the input text boxes white. While they do still work, they aren't much use if no one can see what they are typing! It's a one-line fix, but kind of sinking to wake up to.
2. Back button on the country page - not sure what happened here. I don't think the file was saved locally.
3.  Remove labels from population inputs and use placeholders instead - because people will probably want to put numbers in larger than four characters.